### PR TITLE
Add local/ to .gitignore

### DIFF
--- a/.gitignore
+++ b/.gitignore
@@ -1,1 +1,2 @@
 .statocles
+local/


### PR DESCRIPTION
I used Carton to installed the dependencies, and it stored them in
local/, it's better if git ignore that directory.