### PR TITLE
fix migrations not working under morbo

### DIFF
--- a/blog/2018/12/06/making-a-list-with-yancy/index.markdown
+++ b/blog/2018/12/06/making-a-list-with-yancy/index.markdown
@@ -41,7 +41,7 @@ script](https://perldoc.perl.org/perldata.html#Special-Literals) using
     # Connect to the SQLite database and load our schema from the
     # '@@ migrations' section, below
     my $db = Mojo::SQLite->new( 'sqlite:thelist.db' );
-    $db->auto_migrate(1)->migrations->from_data( 'main' );
+    $db->auto_migrate(1)->migrations->from_data();
 
     # Start the app. Must be the last code of the script.
     app->start;

--- a/blog/2018/12/06/making-a-list-with-yancy/myapp.pl
+++ b/blog/2018/12/06/making-a-list-with-yancy/myapp.pl
@@ -6,7 +6,7 @@ use Mojo::SQLite;
 # Connect to the SQLite database and load our schema from the
 # '@@ migrations' section, below
 my $db = Mojo::SQLite->new( 'sqlite:thelist.db' );
-$db->auto_migrate(1)->migrations->from_data( 'main' );
+$db->auto_migrate(1)->migrations->from_data();
 
 # Configure Yancy
 plugin Yancy => {

--- a/blog/2018/12/17/a-website-for-yancy/index.markdown
+++ b/blog/2018/12/17/a-website-for-yancy/index.markdown
@@ -39,7 +39,7 @@ build the pages table using
         state $db = Mojo::SQLite->new( 'sqlite:' . app->home->child( 'docs.db' ) );
         return $db;
     };
-    app->db->auto_migrate(1)->migrations->from_data( 'main' );
+    app->db->auto_migrate(1)->migrations->from_data();
 
     # Start the app. Must be the code of the script
     app->start;

--- a/blog/2018/12/17/a-website-for-yancy/myapp.pl
+++ b/blog/2018/12/17/a-website-for-yancy/myapp.pl
@@ -7,7 +7,7 @@ helper db => sub {
     state $db = Mojo::SQLite->new( 'sqlite:' . app->home->child( 'docs.db' ) );
     return $db;
 };
-app->db->auto_migrate(1)->migrations->from_data( 'main' );
+app->db->auto_migrate(1)->migrations->from_data();
 
 plugin 'Yancy', {
     backend => { Sqlite => app->db },

--- a/blog/2018/12/18/a-view-to-a-pod/myapp.pl
+++ b/blog/2018/12/18/a-view-to-a-pod/myapp.pl
@@ -7,7 +7,7 @@ helper db => sub {
     state $db = Mojo::SQLite->new( 'sqlite:' . app->home->child( 'docs.db' ) );
     return $db;
 };
-app->db->auto_migrate(1)->migrations->from_data( 'main' );
+app->db->auto_migrate(1)->migrations->from_data();
 
 plugin 'PODViewer', {
     default_module => 'Yancy',

--- a/blog/2018/12/19/you-only-export-twice/myapp.pl
+++ b/blog/2018/12/19/you-only-export-twice/myapp.pl
@@ -7,7 +7,7 @@ helper db => sub {
     state $db = Mojo::SQLite->new( 'sqlite:' . app->home->child( 'docs.db' ) );
     return $db;
 };
-app->db->auto_migrate(1)->migrations->from_data( 'main' );
+app->db->auto_migrate(1)->migrations->from_data();
 
 plugin 'PODViewer', {
     default_module => 'Yancy',

--- a/live/blog/2018/12/06/making-a-list-with-yancy/index.html
+++ b/live/blog/2018/12/06/making-a-list-with-yancy/index.html
@@ -149,7 +149,7 @@ use Mojo::SQLite;
 # Connect to the SQLite database and load our schema from the
 # &#39;@@ migrations&#39; section, below
 my $db = Mojo::SQLite-&gt;new( &#39;sqlite:thelist.db&#39; );
-$db-&gt;auto_migrate(1)-&gt;migrations-&gt;from_data( &#39;main&#39; );
+$db-&gt;auto_migrate(1)-&gt;migrations-&gt;from_data();
 
 # Start the app. Must be the last code of the script.
 app-&gt;start;

--- a/live/blog/2018/12/06/making-a-list-with-yancy/myapp.pl
+++ b/live/blog/2018/12/06/making-a-list-with-yancy/myapp.pl
@@ -6,7 +6,7 @@ use Mojo::SQLite;
 # Connect to the SQLite database and load our schema from the
 # '@@ migrations' section, below
 my $db = Mojo::SQLite->new( 'sqlite:thelist.db' );
-$db->auto_migrate(1)->migrations->from_data( 'main' );
+$db->auto_migrate(1)->migrations->from_data();
 
 # Configure Yancy
 plugin Yancy => {


### PR DESCRIPTION
I don't know why (I have some guesses though), but explicitly using
"main" when loading migrations from data makes them not work under morbo
or hypnotoad. Since it's not needed to specify, I've just removed the
argument (since it's mostly better to be used when in other packages
anyway).