### PR TITLE
fix autoreload advent post to note new development

### DIFF
--- a/blog/2018/12/02/automatic-reload-for-rapid-development/index.markdown
+++ b/blog/2018/12/02/automatic-reload-for-rapid-development/index.markdown
@@ -66,6 +66,11 @@ template](https://metacpan.org/pod/distribution/Mojolicious/lib/Mojolicious/Guid
 our browser, if the server is restarted, our browser will reload the page to
 see the new app!
 
+<aside class="author-update"><b>Author's update</b>: As of [Mojolicious::Plugin::AutoReload version
+0.004](https://metacpan.org/release/PREACTION/Mojolicious-Plugin-AutoReload-0.004),
+you no longer need to use the `auto_reload` helper. It will be added
+automatically just by loading the plugin!</aside>
+
 ## How It Works
 
 This plugin is sheer elegance in its simplicity: When the browser loads the

--- a/blog/2018/12/02/automatic-reload-for-rapid-development/myapp.pl
+++ b/blog/2018/12/02/automatic-reload-for-rapid-development/myapp.pl
@@ -1,4 +1,8 @@
 
+# Author's note: As of Mojolicious::Plugin::AutoReload version 0.004,
+# you no longer need to use the auto_reload helper, which removes the
+# need for a layout here.
+
 use v5.28;
 use Mojolicious::Lite;
 

--- a/theme/css/statocles.css
+++ b/theme/css/statocles.css
@@ -28,3 +28,10 @@ code:not(.hljs) {
   white-space: nowrap;
 }
 
+.author-update {
+    border: 1px solid #313131;
+    border-radius: 5px;
+    background: #EFF1F0;
+    padding: 1em;
+}
+


### PR DESCRIPTION
As of version 0.004, the plugin will now automatically add the correct
script tag without needing an explicit `auto_reload` helper.