### PR TITLE
fix deprecated yancy "collection" configuration

### DIFF
--- a/blog/2017/12/15/day-15-start-a-new-yancy-app/02-yancy.pl
+++ b/blog/2017/12/15/day-15-start-a-new-yancy-app/02-yancy.pl
@@ -6,7 +6,7 @@ $pg->migrations->from_data->migrate;
 
 plugin Yancy => {
     backend => 'pg://localhost/blog',
-    collections => {
+    schema => {
         blog => {
             required => [ 'title', 'markdown', 'html' ],
             properties => {

--- a/blog/2017/12/15/day-15-start-a-new-yancy-app/03-list.pl
+++ b/blog/2017/12/15/day-15-start-a-new-yancy-app/03-list.pl
@@ -6,7 +6,7 @@ $pg->migrations->from_data->migrate;
 
 plugin Yancy => {
     backend => 'pg://localhost/blog',
-    collections => {
+    schema => {
         blog => {
             required => [ 'title', 'markdown', 'html' ],
             properties => {

--- a/blog/2017/12/15/day-15-start-a-new-yancy-app/04-template.pl
+++ b/blog/2017/12/15/day-15-start-a-new-yancy-app/04-template.pl
@@ -6,7 +6,7 @@ $pg->migrations->from_data->migrate;
 
 plugin Yancy => {
     backend => 'pg://localhost/blog',
-    collections => {
+    schema => {
         blog => {
             required => [ 'title', 'markdown', 'html' ],
             properties => {

--- a/blog/2017/12/15/day-15-start-a-new-yancy-app/index.markdown
+++ b/blog/2017/12/15/day-15-start-a-new-yancy-app/index.markdown
@@ -41,11 +41,11 @@ some HTML.
 Next we add [the Yancy
 plugin](http://metacpan.org/pod/Mojolicious::Plugin::Yancy) and tell it
 about our backend and data. Yancy deals with data as a set of
-collections which contain items. For a relational database like
-Postgres, a collection is a table, and an item is a row in that table.
+schemas which contain items. For a relational database like
+Postgres, a schema is a table, and an item is a row in that table.
 
-Yancy uses a JSON schema to describe each item in a collection.
-For our `blog` collection, we have five fields:
+Yancy uses a JSON schema to describe each item. For our `blog`
+schema, we have five fields:
 
 1. `id` which is an auto-generated integer and should be read-only
 2. `title` which is a free-form string which is required
@@ -53,12 +53,12 @@ For our `blog` collection, we have five fields:
 4. `markdown` which is a required Markdown-formatted string
 5. `html`, a string which holds the rendered Markdown and is also required
 
-Here's our configured Yancy `blog` collection:
+Here's our configured Yancy `blog` schema:
 
 %= highlight Perl => begin
 plugin Yancy => {
     backend => 'pg://localhost/blog',
-    collections => {
+    schema => {
         blog => {
             required => [ 'title', 'markdown', 'html' ],
             properties => {
@@ -88,7 +88,7 @@ plugin Yancy => {
 };
 % end
 
-Yancy will build us a rich form for our collection from the field types
+Yancy will build us a rich form for our schema from the field types
 we tell it. Some fields, like the `markdown` field, take additional
 configuration: `x-html-field` tells the Markdown field where to save the
 rendered HTML. There's plenty of customization options in [the Yancy
@@ -107,7 +107,7 @@ Finally, we need some way to display our blog posts.  [Yancy provides
 helpers to access our
 data](http://metacpan.org/pod/Mojolicious::Plugin::Yancy#HELPERS). Let's
 use the `list` helper to display a list of blog posts. This helper takes
-a collection name and gives us a list of items in that collection. It
+a schema name and gives us a list of items in that schema. It
 also allows us to search for items and order them to our liking. Since
 we've got a blog, we will order by the creation date, descending.
 

--- a/blog/2018/12/06/making-a-list-with-yancy/index.markdown
+++ b/blog/2018/12/06/making-a-list-with-yancy/index.markdown
@@ -68,7 +68,7 @@ also give it a few hints to make editing content easier.
         backend => { sqlite => $db },
         # Read the schema configuration from the database
         read_schema => 1,
-        collections => {
+        schema => {
             the_list => {
                 # Show these columns in the Yancy editor
                 'x-list-columns' => [qw( name address is_nice is_delivered )],
@@ -110,7 +110,7 @@ method](https://metacpan.org/pod/Yancy::Controller::Yancy#list):
         controller => 'yancy',
         action => 'list',
         template => 'the_list',
-        collection => 'the_list',
+        schema => 'the_list',
         filter => {
             is_nice => 0,
         },
@@ -166,7 +166,7 @@ in Yancy::Controller::Yancy](https://metacpan.org/pod/Yancy::Controller::Yancy#s
     post '/deliver/:id', {
         controller => 'yancy',
         action => 'set',
-        collection => 'the_list',
+        schema => 'the_list',
         properties => [qw( is_delivered )],
         forward_to => 'the_list.list',
     }, 'the_list.deliver';

--- a/blog/2018/12/06/making-a-list-with-yancy/myapp.pl
+++ b/blog/2018/12/06/making-a-list-with-yancy/myapp.pl
@@ -13,7 +13,7 @@ plugin Yancy => {
     backend => { sqlite => $db },
     # Read the schema configuration from the database
     read_schema => 1,
-    collections => {
+    schema => {
         the_list => {
             # Show these columns in the Yancy editor
             'x-list-columns' => [qw( name address is_nice is_delivered )],
@@ -30,7 +30,7 @@ get '/', {
     controller => 'yancy',
     action => 'list',
     template => 'the_list',
-    collection => 'the_list',
+    schema => 'the_list',
     filter => {
         is_nice => 0,
     },
@@ -40,7 +40,7 @@ get '/', {
 post '/deliver/:id', {
     controller => 'yancy',
     action => 'set',
-    collection => 'the_list',
+    schema => 'the_list',
     properties => [qw( is_delivered )],
     forward_to => 'the_list.list',
 }, 'the_list.deliver';

--- a/blog/2018/12/17/a-website-for-yancy/index.markdown
+++ b/blog/2018/12/17/a-website-for-yancy/index.markdown
@@ -63,7 +63,7 @@ retrieve our pages.
     plugin 'Yancy', {
         backend => { Sqlite => app->db },
         read_schema => 1,
-        collections => {
+        schema => {
             pages => {
                 'x-id-field' => 'path',
                 'x-list-columns' => [qw( path )],
@@ -106,7 +106,7 @@ page's HTML and a layout with some useful links and maybe some
         id => 'index', # Default to index page
         controller => 'yancy',
         action => 'get',
-        collection => 'pages',
+        schema => 'pages',
         template => 'pages',
     };
     # Start the app. Must be the last code of the script

--- a/blog/2018/12/17/a-website-for-yancy/myapp.pl
+++ b/blog/2018/12/17/a-website-for-yancy/myapp.pl
@@ -12,7 +12,7 @@ app->db->auto_migrate(1)->migrations->from_data();
 plugin 'Yancy', {
     backend => { Sqlite => app->db },
     read_schema => 1,
-    collections => {
+    schema => {
         pages => {
             'x-id-field' => 'path',
             'x-list-columns' => [qw( path )],
@@ -34,7 +34,7 @@ get '/*id' => {
     id => 'index', # Default to index page
     controller => 'yancy',
     action => 'get',
-    collection => 'pages',
+    schema => 'pages',
     template => 'pages',
 };
 

--- a/blog/2018/12/18/a-view-to-a-pod/myapp.pl
+++ b/blog/2018/12/18/a-view-to-a-pod/myapp.pl
@@ -18,7 +18,7 @@ plugin 'PODViewer', {
 plugin 'Yancy', {
     backend => { Sqlite => app->db },
     read_schema => 1,
-    collections => {
+    schema => {
         pages => {
             'x-id-field' => 'path',
             'x-list-columns' => [qw( path )],
@@ -40,7 +40,7 @@ get '/*id' => {
     id => 'index', # Default to index page
     controller => 'yancy',
     action => 'get',
-    collection => 'pages',
+    schema => 'pages',
     template => 'pages',
 };
 

--- a/blog/2018/12/19/you-only-export-twice/myapp.pl
+++ b/blog/2018/12/19/you-only-export-twice/myapp.pl
@@ -18,7 +18,7 @@ plugin 'PODViewer', {
 plugin 'Yancy', {
     backend => { Sqlite => app->db },
     read_schema => 1,
-    collections => {
+    schema => {
         pages => {
             'x-id-field' => 'path',
             'x-list-columns' => [qw( path )],
@@ -40,7 +40,7 @@ get '/*id' => {
     id => 'index', # Default to index page
     controller => 'yancy',
     action => 'get',
-    collection => 'pages',
+    schema => 'pages',
     template => 'pages',
 };
 


### PR DESCRIPTION
Yancy will be renaming "collection" to "schema" in version 2. Until
then, using "collections" will cause a deprecation message. Using
"schema" right now prevents this deprecation message.